### PR TITLE
Änderungsvorschläge zur Brückenspannung

### DIFF
--- a/chapters/1_chap.tex
+++ b/chapters/1_chap.tex
@@ -131,7 +131,7 @@
                                 &= \left(\rho_{H_2O} - \rho_{Al}\right)V_{Ring} \cdot g
             \end{align}
             %
-        \subsection{Deriving an Equation for the bridge voltage}\label{sec:A4 equation for full bridge circuit}% A4
+        \subsection{Deriving an Equation for the Bridge Voltage}\label{sec:A4 equation for full bridge circuit}% A4
         %
             \begin{equation}
                 U_{Br} = U_2 - U_4 = U_3 - U_1 \quad \text{with} \quad U_{Br} = 0 \text{for} \frac{R_1}{R_2} = \frac{R_3}{R_4}
@@ -160,7 +160,7 @@
             \end{equation}
             the bridge voltage can be expressed as
             \begin{align}
-                U_{Br} = U_0 \cdot \left( \frac{\Delta s}{s} + \nu \cdot \frac{3 \Delta l}{l}\right)
+                U_{Br} = U_0 \cdot \left( \frac{\Delta \varrho}{\varrho} + \frac{\Delta l}{l} + \nu \cdot \frac{2 \Delta l}{l}\right)
             \end{align}
             %
         \subsection{Schematic Diagram of a Full Bridge}\label{sec:A5 schematic diagram full bridge}% A5


### PR DESCRIPTION
Vielleicht sah mein "roh" auf dem Foto zu sehr aus wie ein "s". Jedenfalls hatte ich mir das so vorgestellt. Die Querkontraktion müsste sich auch nur auf Dicke und Breite beziehen, deshalb kann man das nicht zu "3 nu" zusammenfassen. Das war zumindest meine Überlegung.